### PR TITLE
#12 gitignoreの内容をdjango用に最適化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ mysql/*
 # django関連
 static/admin/*
 genie/*
+genie
+*.log
+*.pyc
+__pycache__/
+db-volumes/
+db.sqlite3


### PR DESCRIPTION
gitigonreにdjango用の内容を記載。
参考サイトは以下。
"https://zenn.dev/wtkn25/articles/django-gitignore"